### PR TITLE
Fix directory name in README distributed training section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ Training TGN model on the GDELT dataset on more than 1 servers, each server is r
    - `NPROC_PER_NODE`: The number of GPU for each servers
 
 ```sh
-cd script
+cd scripts
 ./run_offline_dist.sh TGN GDELT
 ```


### PR DESCRIPTION
## Summary
- correct README reference to `scripts` directory for distributed training instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6859bc0c9c448328b378cc9cb1a5eee2