### PR TITLE
Fix duplicate load_partition_table definition

### DIFF
--- a/gnnflow/utils.py
+++ b/gnnflow/utils.py
@@ -80,34 +80,6 @@ def load_partition_table(dataset: str):
     """
     Loads the dataset and returns the dataframes for the train, validation, test and
     whole dataset.
-
-
-    Args:
-        dataset: the name of the dataset.
-
-    Returns:
-        pt: partition_table of the first 60% data of the dataset
-    """
-
-    data_dir = os.path.join(get_project_root_dir(), "partition_data")
-
-    path = os.path.join(data_dir, dataset + '_metis_partition.pt')
-
-    if not os.path.exists(path):
-        logging.info(
-            "Didn't find Partition table under path: {}, using default partition algorithm to partition...".format(path))
-        return None
-
-    logging.info(
-        "Find corresponding file under path {}. Using this file to skip the initial partition phase!".format(path))
-    pt = torch.load(path)
-    return pt
-
-
-def load_partition_table(dataset: str):
-    """
-    Loads the dataset and returns the dataframes for the train, validation, test and
-    whole dataset.
     Args:
         dataset: the name of the dataset.
     Returns:


### PR DESCRIPTION
## Summary
- remove redundant `load_partition_table` definition in `gnnflow/utils.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gnnflow')*

------
https://chatgpt.com/codex/tasks/task_e_6859ba29ed288328879d534f6ffb2650